### PR TITLE
Add mod() function

### DIFF
--- a/src/math.ts
+++ b/src/math.ts
@@ -13,6 +13,10 @@ export function fract(x: number): number {
     return x - Math.floor(x);
 }
 
+export function mod(value: number, dividend: number) {
+    return ((value % dividend) + dividend) % dividend;
+}
+
 export function clamp(value: number, min: number, max: number): number {
     return Math.max(min, Math.min(value, max));
 }


### PR DESCRIPTION
Adds modulo function which behaves correctly with negative numbers.
JavaScript's default `%` operator behaves differently than generally expected:
```js
console.log(-1 % 10);
// Logs -1, but in other languages it typically logs 9
```
This is just a fix for that:
```js
console.log(c2.mod(-1 % 10));
// Logs 9